### PR TITLE
fix song downloading / add song covers / small ui overhaul

### DIFF
--- a/assets/menu.bsml
+++ b/assets/menu.bsml
@@ -1,10 +1,10 @@
-<vertical xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:noNamespaceSchemaLocation='https://raw.githubusercontent.com/RedBrumbler/Quest-BSML-Docs/gh-pages/schema.xsd'>
-    <horizontal bg='panel-top-gradient'>
+<vertical xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:noNamespaceSchemaLocation='https://raw.githubusercontent.com/RedBrumbler/Quest-BSML-Docs/gh-pages/schema.xsd' child-control-height="false" pad-top='2'>
+    <horizontal bg='panel-top-gradient' preferred-height='5'>
         <text text='Song Requests' align='Center' italics='true'/>
     </horizontal>
     <horizontal preferred-height='70' pad-top='0' pad-bottom='2' preferred-width='80'>
-        <vertical preferred-width='70' pad-top="3" pad-bottom="10">
-            <list id='songTableData' select-cell='SelectSong' visible-cells='8' show-scrollbar='true' stick-scrolling="true" />
+        <vertical preferred-width='78' pad-top="0" pad-bottom="0">
+            <list id='songTableData' select-cell='SelectSong' visible-cells='5' show-scrollbar='true' stick-scrolling="true" />
         </vertical>
     </horizontal>
 </vertical>

--- a/assets/songItem.bsml
+++ b/assets/songItem.bsml
@@ -1,13 +1,15 @@
 <bg xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'  xsi:noNamespaceSchemaLocation='https://raw.githubusercontent.com/RedBrumbler/Quest-BSML-Docs/gh-pages/schema.xsd'>
-	<vertical id='bgContainer' bg='round-rect-panel' horizontal-fit='Unconstrained' preferred-height='7' vertical-fit='PreferredSize'/>
-	<vertical id='bgProgress' horizontal-fit='Unconstrained' preferred-height='1' vertical-fit='PreferredSize' background='panel-fade-gradient' anchor-pos-y='-2.875'/>
-	<vertical horizontal-fit='Unconstrained' pad='1' preferred-height='8' vertical-fit='PreferredSize'>
-		<horizontal spacing='2'>
-			<text id='songName' align='MidlineLeft' font-size='2.7' overflow-mode='Ellipsis' word-wrapping='false'/>
-			<text id='levelAuthorName' align='MidlineRight' font-size='2.3' overflow-mode='Ellipsis' word-wrapping='false' color='#CCC'/>
-		</horizontal>
-		<horizontal pad-top='2'>
-			<text id='statusLabel' align='MidlineLeft' font-size='3' word-wrapping='false' color='cyan'/>
-		</horizontal>
-	</vertical>
+	<vertical id='bgContainer' bg='round-rect-panel' horizontal-fit='Unconstrained' preferred-height='14' vertical-fit='PreferredSize'/>
+	<horizontal horizontal-fit='Unconstrained' child-align='MiddleLeft' pad='1' spacing='2' child-expand-width='false'>
+		<image id='coverImage' preferred-width='10' preferred-height='10' min-width='10' min-height='10' preserve-aspect='true'/>
+		<vertical horizontal-fit='Unconstrained' preferred-height='10' vertical-fit='PreferredSize' child-expand-width='true'>
+			<horizontal spacing='2' child-expand-width='true'>
+				<text id='songName' align='MidlineLeft' font-size='3.5' overflow-mode='Ellipsis' word-wrapping='false'/>
+				<text id='levelAuthorName' align='MidlineRight' font-size='2.5' overflow-mode='Ellipsis' word-wrapping='false' color='#CCC'/>
+			</horizontal>
+			<horizontal pad-top='1'>
+				<text id='statusLabel' align='MidlineLeft' font-size='3' word-wrapping='false' color='cyan'/>
+			</horizontal>
+		</vertical>
+	</horizontal>
 </bg>

--- a/include/FloatingMenu.hpp
+++ b/include/FloatingMenu.hpp
@@ -14,6 +14,8 @@
 #include "GlobalNamespace/SoloFreePlayFlowCoordinator.hpp"
 #include "GlobalNamespace/MultiplayerLevelSelectionFlowCoordinator.hpp"
 #include "GlobalNamespace/LevelSelectionFlowCoordinator.hpp"
+#include "System/Collections/Generic/List_1.hpp"
+#include "UnityEngine/Sprite.hpp"
 
 
 using namespace GlobalNamespace;
@@ -36,6 +38,7 @@ DECLARE_CLASS_CODEGEN_INTERFACES(TSRQ, FloatingMenu, UnityEngine::MonoBehaviour,
     DECLARE_INSTANCE_METHOD(void, SelectSong, HMUI::TableView* table, int id);
     DECLARE_INSTANCE_METHOD(void, PostParse);
     DECLARE_INSTANCE_FIELD(BSML::CustomListTableData*, songTableData);
+    DECLARE_INSTANCE_FIELD(System::Collections::Generic::List_1<UnityEngine::Sprite*>*, spriteCache);
 
     DECLARE_OVERRIDE_METHOD_MATCH(HMUI::TableCell*, CellForIdx, &HMUI::TableView::IDataSource::CellForIdx, HMUI::TableView* tableView, int idx);
     DECLARE_OVERRIDE_METHOD_MATCH(float, CellSize, &HMUI::TableView::IDataSource::CellSize);

--- a/include/SongListCell.hpp
+++ b/include/SongListCell.hpp
@@ -29,7 +29,7 @@ DECLARE_CLASS_CODEGEN(TSRQ, CustomSongListTableCell, HMUI::TableCell,
     DECLARE_OVERRIDE_METHOD_MATCH(void, HighlightDidChange, &HMUI::SelectableCell::HighlightDidChange, HMUI::SelectableCell::TransitionType transitionType);
     DECLARE_OVERRIDE_METHOD_MATCH(void, WasPreparedForReuse, &HMUI::TableCell::WasPreparedForReuse);
     DECLARE_INSTANCE_FIELD(HMUI::ImageView*, bgContainer);
-    DECLARE_INSTANCE_FIELD(HMUI::ImageView*, bgProgress);
+    DECLARE_INSTANCE_FIELD(HMUI::ImageView*, coverImage);
     DECLARE_INSTANCE_FIELD(TMPro::TextMeshProUGUI*, songName);
     DECLARE_INSTANCE_FIELD(TMPro::TextMeshProUGUI*, levelAuthorName);
     DECLARE_INSTANCE_FIELD(TMPro::TextMeshProUGUI*, statusLabel);
@@ -38,7 +38,7 @@ public:
     // Song entry to have a reference to the song data
     TSRQ::SongListObject* entry;
     CustomSongListTableCell* PopulateWithSongData(TSRQ::SongListObject* songListObject);
-    // void UpdateProgress();
+    void UpdateProgress(float progress);
     // void RefreshBar();
     void RefreshBgState();
 )

--- a/include/SongListObject.hpp
+++ b/include/SongListObject.hpp
@@ -15,6 +15,7 @@ namespace TSRQ
         std::optional<BeatSaver::Models::Beatmap> song;
         bool downloading = false;
         bool isDownloaded = false;
+        bool failed = false;
 
         void setSong(std::optional<BeatSaver::Models::Beatmap> song) {
             this->song = song;
@@ -22,10 +23,15 @@ namespace TSRQ
 
         void setIsDownloading(bool downloading) {
             this->downloading = downloading;
+            if (downloading) this->failed = false;
         }
 
         void setIsDownloaded(bool isDownloaded) {
             this->isDownloaded = isDownloaded;
+        }
+        
+        void setFailed(bool failed) {
+            this->failed = failed;
         }
     };
 }

--- a/include/SongListObject.hpp
+++ b/include/SongListObject.hpp
@@ -18,6 +18,7 @@ namespace TSRQ
         bool downloading = false;
         bool isDownloaded = false;
         bool failed = false;
+        bool songNotFound = false;
         float progress = 0.0f;
         UnityEngine::Sprite* cover = nullptr;
         std::function<void(float)> progressUpdateCallback;

--- a/include/SongListObject.hpp
+++ b/include/SongListObject.hpp
@@ -20,7 +20,7 @@ namespace TSRQ
         bool failed = false;
         bool songNotFound = false;
         float progress = 0.0f;
-        UnityEngine::Sprite* cover = nullptr;
+        SafePtrUnity<UnityEngine::Sprite> cover;
         std::function<void(float)> progressUpdateCallback;
 
         void setSong(std::optional<BeatSaver::Models::Beatmap> song) {

--- a/include/SongListObject.hpp
+++ b/include/SongListObject.hpp
@@ -8,6 +8,8 @@
 #include "assets.hpp"
 #include "beatsaverplusplus/shared/Models/Beatmap.hpp"
 
+#include "UnityEngine/Sprite.hpp"
+
 namespace TSRQ
 {
     class SongListObject {
@@ -16,6 +18,9 @@ namespace TSRQ
         bool downloading = false;
         bool isDownloaded = false;
         bool failed = false;
+        float progress = 0.0f;
+        UnityEngine::Sprite* cover = nullptr;
+        std::function<void(float)> progressUpdateCallback;
 
         void setSong(std::optional<BeatSaver::Models::Beatmap> song) {
             this->song = song;
@@ -23,7 +28,10 @@ namespace TSRQ
 
         void setIsDownloading(bool downloading) {
             this->downloading = downloading;
-            if (downloading) this->failed = false;
+            if (downloading) {
+                this->failed = false;
+                this->progress = 0.0f;
+            }
         }
 
         void setIsDownloaded(bool isDownloaded) {

--- a/mod.template.json
+++ b/mod.template.json
@@ -5,7 +5,7 @@
   "id": "${mod_id}",
   "modloader": "Scotland2",
   "author": "hdgamer1404Jonas",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "packageId": "com.beatgames.beatsaber",
   "packageVersion": "1.37.0_9064817954",
   "description": "Let your viewers suggest maps",

--- a/qpm.shared.json
+++ b/qpm.shared.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/QuestPackageManager/QPM.Package/refs/heads/main/qpm.shared.schema.json",
   "config": {
     "version": "0.4.0",
     "sharedDir": "shared",

--- a/src/FloatingMenu.cpp
+++ b/src/FloatingMenu.cpp
@@ -12,6 +12,14 @@
 #include "UnityEngine/Resources.hpp"
 #include "UnityEngine/SceneManagement/Scene.hpp"
 #include "UnityEngine/SceneManagement/SceneManager.hpp"
+#include "UnityEngine/Texture2D.hpp"
+#include "UnityEngine/ImageConversion.hpp"
+#include "UnityEngine/Sprite.hpp"
+#include "UnityEngine/Rect.hpp"
+#include "UnityEngine/Vector2.hpp"
+#include "UnityEngine/Vector4.hpp"
+#include "UnityEngine/SpriteMeshType.hpp"
+#include "UnityEngine/TextureFormat.hpp"
 #include "assets.hpp"
 #include "beatsaverplusplus/shared/BeatSaver.hpp"
 #include "bsml/shared/BSML-Lite/Creation/Image.hpp"
@@ -33,7 +41,7 @@ SafePtrUnity<TSRQ::FloatingMenu> TSRQ::FloatingMenu::instance;
 using namespace GlobalNamespace;
 
 // Runs on creation
-void TSRQ::FloatingMenu::ctor() { this->cellSize = 8.05f; }
+void TSRQ::FloatingMenu::ctor() { this->cellSize = 14.0f; }
 
 void TSRQ::FloatingMenu::Initialize() {
   if (initialized)
@@ -54,6 +62,8 @@ void TSRQ::FloatingMenu::Initialize() {
   // "Move by Pressing a trigger");
 
   BSML::Lite::AddHoverHint(menu, "Move by Pressing a trigger");
+
+  BeatSaver::API::Init(SongCore::API::Loading::GetPreferredCustomLevelPath());
 
   if (this->songTableData != nullptr &&
       this->songTableData->m_CachedPtr.m_value != nullptr) {
@@ -126,7 +136,7 @@ HMUI::TableCell *TSRQ::FloatingMenu::CellForIdx(HMUI::TableView *tableView,
 
 void TSRQ::FloatingMenu::RefreshTable(bool fullReload) {
   INFO("TSRQ: RefreshTable");
-  BSML::MainThreadScheduler::Schedule([this] {
+  BSML::MainThreadScheduler::Schedule([this, fullReload] {
     // Sort entry list
     // std::stable_sort(downloadEntryList.begin(), downloadEntryList.end(),
     //     [] (DownloadHistoryEntry* entry1, DownloadHistoryEntry* entry2)
@@ -134,7 +144,11 @@ void TSRQ::FloatingMenu::RefreshTable(bool fullReload) {
     //         return (entry1->orderValue() < entry2->orderValue());
     //     }
     // );
-    this->songListTable()->ReloadData();
+    if (fullReload) {
+        this->songListTable()->ReloadData();
+    } else {
+        this->songListTable()->ReloadDataKeepingPosition();
+    }
     // coro(this->limitedFullTableReload->Call());
   });
 }
@@ -164,7 +178,7 @@ void TSRQ::FloatingMenu::SelectSong(HMUI::TableView *table, int id) {
           INFO("TSRQ: level is empty");
           songList[id]->setIsDownloaded(false);
           songList[id]->setFailed(true);
-          this->RefreshTable();
+          this->RefreshTable(false);
           return;
         }
       });
@@ -174,13 +188,24 @@ void TSRQ::FloatingMenu::SelectSong(HMUI::TableView *table, int id) {
   }
 
   songList[id]->downloading = true;
-  this->RefreshTable();
+  songList[id]->progress = 0.0f;
+  this->RefreshTable(false);
 
   std::thread([this, id] {
     // Construct dl info and start dl
     auto dlInfo =
         BeatSaver::API::BeatmapDownloadInfo(songList[id]->song.value());
-    std::optional<std::string> path = BeatSaver::API::DownloadBeatmap(dlInfo);
+    
+    auto progressCallback = [this, id](float progress) {
+        BSML::MainThreadScheduler::Schedule([this, id, progress] {
+            songList[id]->progress = progress;
+            if(songList[id]->progressUpdateCallback) {
+                songList[id]->progressUpdateCallback(progress);
+            }
+        });
+    };
+
+    std::optional<std::string> path = BeatSaver::API::DownloadBeatmap(dlInfo, progressCallback);
 
     if (path.has_value()) {
         auto task = SongCore::API::Loading::RefreshSongs(false);
@@ -195,7 +220,7 @@ void TSRQ::FloatingMenu::SelectSong(HMUI::TableView *table, int id) {
       } else {
           songList[id]->setFailed(true);
       }
-      this->RefreshTable();
+      this->RefreshTable(false);
     });
   }).detach();
 }
@@ -285,16 +310,43 @@ void TSRQ::FloatingMenu::push(TSRQ::SongListObject *songListObject) {
   std::optional<BeatSaver::Models::Beatmap> song = songListObject->song;
   if (!song.has_value())
     return;
+  
+  if (song->GetVersions().empty()) {
+      ERROR("Song has no versions!");
+      return;
+  }
+
   INFO("TSRQ: Pushing song {}", song->GetMetadata().GetSongName());
 
-  std::optional<SongCore::SongLoader::CustomBeatmapLevel *> local =
+  SongCore::SongLoader::CustomBeatmapLevel *local =
       SongCore::API::Loading::GetLevelByHash(
           song->GetVersions().front().GetHash());
 
-  if (local.has_value()) {
-    songListObject->isDownloaded = true;
+  if (local != nullptr) {
+    // Verify that the level actually exists on disk
+    std::string customLevelPath(local->get_customLevelPath());
+    if (std::filesystem::exists(customLevelPath)) {
+        songListObject->isDownloaded = true;
+    }
   }
 
-  this->songList.push_back(songListObject);
-  this->RefreshTable();
+  // Fetch cover image
+  std::thread([songListObject, this] {
+      auto coverFuture = BeatSaver::API::GetCoverImageAsync(songListObject->song.value().GetVersions().front());
+      auto coverData = coverFuture.get();
+      if (coverData.IsSuccessful() && coverData.responseData.has_value()) {
+           std::vector<uint8_t> bytes = coverData.responseData.value();
+           BSML::MainThreadScheduler::Schedule([songListObject, bytes, this]() mutable {
+               Array<uint8_t>* byteArray = il2cpp_utils::vectorToArray(bytes);
+               UnityEngine::Texture2D* texture = UnityEngine::Texture2D::New_ctor(2, 2, UnityEngine::TextureFormat::RGBA32, false);
+               UnityEngine::ImageConversion::LoadImage(texture, byteArray);
+               UnityEngine::Sprite* sprite = UnityEngine::Sprite::Create(texture, UnityEngine::Rect(0, 0, texture->get_width(), texture->get_height()), UnityEngine::Vector2(0.5f, 0.5f), 100.0f, 0, UnityEngine::SpriteMeshType::FullRect, UnityEngine::Vector4::get_zero(), false);
+               songListObject->cover = sprite;
+               this->RefreshTable(false);
+           });
+      }
+  }).detach();
+
+  this->songList.insert(this->songList.begin(), songListObject);
+  this->RefreshTable(false);
 }

--- a/src/FloatingMenu.cpp
+++ b/src/FloatingMenu.cpp
@@ -153,7 +153,7 @@ void TSRQ::FloatingMenu::SelectSong(HMUI::TableView *table, int id) {
 
       BeatSaver::Models::Beatmap songToPlay = songList[id]->song.value();
 
-      BSML::MainThreadScheduler::Schedule([this, songToPlay] {
+      BSML::MainThreadScheduler::Schedule([this, songToPlay, id] {
         auto versions = songToPlay.GetVersions();
         auto &beatmap = versions.front();
         std::string mapHash = beatmap.GetHash();
@@ -162,6 +162,9 @@ void TSRQ::FloatingMenu::SelectSong(HMUI::TableView *table, int id) {
           EnterSolo(level);
         } else {
           INFO("TSRQ: level is empty");
+          songList[id]->setIsDownloaded(false);
+          songList[id]->setFailed(true);
+          this->RefreshTable();
           return;
         }
       });
@@ -179,17 +182,19 @@ void TSRQ::FloatingMenu::SelectSong(HMUI::TableView *table, int id) {
         BeatSaver::API::BeatmapDownloadInfo(songList[id]->song.value());
     std::optional<std::string> path = BeatSaver::API::DownloadBeatmap(dlInfo);
 
-    BSML::MainThreadScheduler::Schedule([this, id] {
+    if (path.has_value()) {
+        auto task = SongCore::API::Loading::RefreshSongs(false);
+        // Wait for songs to be refreshed
+        task.wait();
+    }
+
+    BSML::MainThreadScheduler::Schedule([this, id, path] {
       songList[id]->setIsDownloading(false);
-      this->RefreshTable();
-    });
-
-    auto task = SongCore::API::Loading::RefreshSongs(false);
-    // Wait for songs to be refreshed
-    task.wait();
-
-    BSML::MainThreadScheduler::Schedule([this, id] {
-      songList[id]->setIsDownloaded(true);
+      if (path.has_value()) {
+          songList[id]->setIsDownloaded(true);
+      } else {
+          songList[id]->setFailed(true);
+      }
       this->RefreshTable();
     });
   }).detach();

--- a/src/FloatingMenu.cpp
+++ b/src/FloatingMenu.cpp
@@ -177,7 +177,7 @@ void TSRQ::FloatingMenu::SelectSong(HMUI::TableView *table, int id) {
         } else {
           INFO("TSRQ: level is empty");
           songList[id]->setIsDownloaded(false);
-          songList[id]->setFailed(true);
+          songList[id]->songNotFound = true;
           this->RefreshTable(false);
           return;
         }
@@ -189,6 +189,8 @@ void TSRQ::FloatingMenu::SelectSong(HMUI::TableView *table, int id) {
 
   songList[id]->downloading = true;
   songList[id]->progress = 0.0f;
+  songList[id]->songNotFound = false;
+  songList[id]->failed = false;
   this->RefreshTable(false);
 
   std::thread([this, id] {

--- a/src/FloatingMenu.cpp
+++ b/src/FloatingMenu.cpp
@@ -41,7 +41,10 @@ SafePtrUnity<TSRQ::FloatingMenu> TSRQ::FloatingMenu::instance;
 using namespace GlobalNamespace;
 
 // Runs on creation
-void TSRQ::FloatingMenu::ctor() { this->cellSize = 14.0f; }
+void TSRQ::FloatingMenu::ctor() { 
+    this->cellSize = 14.0f; 
+    this->spriteCache = System::Collections::Generic::List_1<UnityEngine::Sprite*>::New_ctor();
+}
 
 void TSRQ::FloatingMenu::Initialize() {
   if (initialized)
@@ -343,6 +346,9 @@ void TSRQ::FloatingMenu::push(TSRQ::SongListObject *songListObject) {
                UnityEngine::Texture2D* texture = UnityEngine::Texture2D::New_ctor(2, 2, UnityEngine::TextureFormat::RGBA32, false);
                UnityEngine::ImageConversion::LoadImage(texture, byteArray);
                UnityEngine::Sprite* sprite = UnityEngine::Sprite::Create(texture, UnityEngine::Rect(0, 0, texture->get_width(), texture->get_height()), UnityEngine::Vector2(0.5f, 0.5f), 100.0f, 0, UnityEngine::SpriteMeshType::FullRect, UnityEngine::Vector4::get_zero(), false);
+               UnityEngine::Object::DontDestroyOnLoad(texture);
+               UnityEngine::Object::DontDestroyOnLoad(sprite);
+               if (this->spriteCache) this->spriteCache->Add(sprite);
                songListObject->cover = sprite;
                this->RefreshTable(false);
            });

--- a/src/SongListCell.cpp
+++ b/src/SongListCell.cpp
@@ -2,6 +2,7 @@
 
 #include "UnityEngine/RectTransform.hpp"
 #include "main.hpp"
+#include "logging.hpp"
 #include "bsml/shared/BSML/MainThreadScheduler.hpp"
 #include "songcore/shared/SongCore.hpp"
 
@@ -10,7 +11,16 @@ namespace TSRQ {
 CustomSongListTableCell *CustomSongListTableCell::PopulateWithSongData(
     TSRQ::SongListObject *songListObject) {
 
+  if (!songListObject) {
+      ERROR("songListObject is null");
+      return this;
+  }
+
   std::optional<BeatSaver::Models::Beatmap> song = songListObject->song;
+  if (!song.has_value()) {
+      ERROR("song is empty");
+      return this;
+  }
 
   if (songListObject->isDownloaded) {
       auto versions = song.value().GetVersions();
@@ -25,13 +35,17 @@ CustomSongListTableCell *CustomSongListTableCell::PopulateWithSongData(
       }
   }
 
-  songName->set_text(song.value().GetName());
-  levelAuthorName->set_text(song.value().GetMetadata().GetLevelAuthorName());
+  if (songName)
+      songName->set_text(song.value().GetName());
+  if (levelAuthorName)
+      levelAuthorName->set_text(song.value().GetMetadata().GetLevelAuthorName());
 
-  if (songListObject->cover) {
-      coverImage->set_sprite(songListObject->cover);
-  } else {
-      coverImage->set_sprite(nullptr);
+  if (coverImage) {
+      if (songListObject->cover) {
+          coverImage->set_sprite(songListObject->cover.ptr());
+      } else {
+          coverImage->set_sprite(nullptr);
+      }
   }
 
   songListObject->progressUpdateCallback = [this](float progress) {
@@ -40,21 +54,23 @@ CustomSongListTableCell *CustomSongListTableCell::PopulateWithSongData(
        });
   };
 
-  if (songListObject->isDownloaded) {
-    statusLabel->set_text("In Collection. Click to Play");
-    statusLabel->set_color(UnityEngine::Color::get_green());
-  } else if (songListObject->downloading) {
-    statusLabel->set_text(fmt::format("Downloading... {:.0f}%", songListObject->progress * 100));
-    statusLabel->set_color(UnityEngine::Color::get_cyan());
-  } else if (songListObject->songNotFound) {
-    statusLabel->set_text("Song not found. Click to redownload");
-    statusLabel->set_color(UnityEngine::Color(1.0f, 0.5f, 0.0f, 1.0f));
-  } else if (songListObject->failed) {
-    statusLabel->set_text("Download Failed. Click to retry");
-    statusLabel->set_color(UnityEngine::Color::get_red());
-  } else {
-    statusLabel->set_text("Click to download");
-    statusLabel->set_color(UnityEngine::Color::get_cyan());
+  if (statusLabel) {
+      if (songListObject->isDownloaded) {
+        statusLabel->set_text("In Collection. Click to Play");
+        statusLabel->set_color(UnityEngine::Color::get_green());
+      } else if (songListObject->downloading) {
+        statusLabel->set_text(fmt::format("Downloading... {:.0f}%", songListObject->progress * 100));
+        statusLabel->set_color(UnityEngine::Color::get_cyan());
+      } else if (songListObject->songNotFound) {
+        statusLabel->set_text("Song not found. Click to redownload");
+        statusLabel->set_color(UnityEngine::Color(1.0f, 0.5f, 0.0f, 1.0f));
+      } else if (songListObject->failed) {
+        statusLabel->set_text("Download Failed. Click to retry");
+        statusLabel->set_color(UnityEngine::Color::get_red());
+      } else {
+        statusLabel->set_text("Click to download");
+        statusLabel->set_color(UnityEngine::Color::get_cyan());
+      }
   }
 
   this->entry = songListObject;
@@ -62,7 +78,7 @@ CustomSongListTableCell *CustomSongListTableCell::PopulateWithSongData(
 }
 
 void CustomSongListTableCell::UpdateProgress(float progress) {
-    if (entry && entry->downloading) {
+    if (entry && entry->downloading && statusLabel) {
         statusLabel->set_text(fmt::format("Downloading... {:.0f}%", progress * 100));
     }
 }

--- a/src/SongListCell.cpp
+++ b/src/SongListCell.cpp
@@ -27,13 +27,17 @@ CustomSongListTableCell *CustomSongListTableCell::PopulateWithSongData(
   };
 
   if (songListObject->isDownloaded) {
-    statusLabel->set_text("In Collection");
+    statusLabel->set_text("In Collection. Click to Play");
+    statusLabel->set_color(UnityEngine::Color::get_green());
   } else if (songListObject->downloading) {
     statusLabel->set_text(fmt::format("Downloading... {:.0f}%", songListObject->progress * 100));
+    statusLabel->set_color(UnityEngine::Color::get_cyan());
   } else if (songListObject->failed) {
-    statusLabel->set_text("Download Failed");
+    statusLabel->set_text("Download Failed. Click to retry");
+    statusLabel->set_color(UnityEngine::Color::get_red());
   } else {
     statusLabel->set_text("Click to download");
+    statusLabel->set_color(UnityEngine::Color::get_cyan());
   }
 
   this->entry = songListObject;

--- a/src/SongListCell.cpp
+++ b/src/SongListCell.cpp
@@ -2,6 +2,7 @@
 
 #include "UnityEngine/RectTransform.hpp"
 #include "main.hpp"
+#include "bsml/shared/BSML/MainThreadScheduler.hpp"
 
 DEFINE_TYPE(TSRQ, CustomSongListTableCell)
 namespace TSRQ {
@@ -13,38 +14,41 @@ CustomSongListTableCell *CustomSongListTableCell::PopulateWithSongData(
   songName->set_text(song.value().GetName());
   levelAuthorName->set_text(song.value().GetMetadata().GetLevelAuthorName());
 
+  if (songListObject->cover) {
+      coverImage->set_sprite(songListObject->cover);
+  } else {
+      coverImage->set_sprite(nullptr);
+  }
+
+  songListObject->progressUpdateCallback = [this](float progress) {
+       BSML::MainThreadScheduler::Schedule([this, progress] {
+           UpdateProgress(progress);
+       });
+  };
+
   if (songListObject->isDownloaded) {
     statusLabel->set_text("In Collection");
-    this->entry = songListObject;
-    return this;
   } else if (songListObject->downloading) {
-    statusLabel->set_text("Downloading...");
-    this->entry = songListObject;
-    return this;
+    statusLabel->set_text(fmt::format("Downloading... {:.0f}%", songListObject->progress * 100));
   } else if (songListObject->failed) {
     statusLabel->set_text("Download Failed");
-    this->entry = songListObject;
-    return this;
   } else {
     statusLabel->set_text("Click to download");
   }
 
-  /*songName->set_text(beatmap->GetMetadata().GetSongName() + " | " +
-  beatmap->GetMetadata().GetSongAuthorName());
-  levelAuthorName->set_text(beatmap->GetMetadata().GetLevelAuthorName());*/
-
-  // statusLabel->set_text(entry->statusMessage());
   this->entry = songListObject;
-  // entry->UpdateProgressHandler = [this]() {
-  //     UpdateProgress();
-  // };
   return this;
+}
+
+void CustomSongListTableCell::UpdateProgress(float progress) {
+    if (entry && entry->downloading) {
+        statusLabel->set_text(fmt::format("Downloading... {:.0f}%", progress * 100));
+    }
 }
 
 void CustomSongListTableCell::RefreshBgState() {
   bgContainer->set_color(
       UnityEngine::Color(0, 0, 0, highlighted ? 0.8f : 0.45f));
-  // RefreshBar();
 }
 
 // void CustomSongListTableCell::RefreshBar() {
@@ -82,6 +86,8 @@ void CustomSongListTableCell::HighlightDidChange(
 }
 
 void CustomSongListTableCell::WasPreparedForReuse() {
-  // entry->UpdateProgressHandler = nullptr;
+  if (entry) {
+      entry->progressUpdateCallback = nullptr;
+  }
 }
 } // namespace TSRQ

--- a/src/SongListCell.cpp
+++ b/src/SongListCell.cpp
@@ -3,6 +3,7 @@
 #include "UnityEngine/RectTransform.hpp"
 #include "main.hpp"
 #include "bsml/shared/BSML/MainThreadScheduler.hpp"
+#include "songcore/shared/SongCore.hpp"
 
 DEFINE_TYPE(TSRQ, CustomSongListTableCell)
 namespace TSRQ {
@@ -10,6 +11,19 @@ CustomSongListTableCell *CustomSongListTableCell::PopulateWithSongData(
     TSRQ::SongListObject *songListObject) {
 
   std::optional<BeatSaver::Models::Beatmap> song = songListObject->song;
+
+  if (songListObject->isDownloaded) {
+      auto versions = song.value().GetVersions();
+      if (!versions.empty()) {
+          auto &beatmap = versions.front();
+          std::string mapHash = beatmap.GetHash();
+          auto level = SongCore::API::Loading::GetLevelByHash(mapHash);
+          if (level == nullptr) {
+              songListObject->isDownloaded = false;
+              songListObject->songNotFound = true;
+          }
+      }
+  }
 
   songName->set_text(song.value().GetName());
   levelAuthorName->set_text(song.value().GetMetadata().GetLevelAuthorName());
@@ -32,6 +46,9 @@ CustomSongListTableCell *CustomSongListTableCell::PopulateWithSongData(
   } else if (songListObject->downloading) {
     statusLabel->set_text(fmt::format("Downloading... {:.0f}%", songListObject->progress * 100));
     statusLabel->set_color(UnityEngine::Color::get_cyan());
+  } else if (songListObject->songNotFound) {
+    statusLabel->set_text("Song not found. Click to redownload");
+    statusLabel->set_color(UnityEngine::Color(1.0f, 0.5f, 0.0f, 1.0f));
   } else if (songListObject->failed) {
     statusLabel->set_text("Download Failed. Click to retry");
     statusLabel->set_color(UnityEngine::Color::get_red());

--- a/src/SongListCell.cpp
+++ b/src/SongListCell.cpp
@@ -22,19 +22,6 @@ CustomSongListTableCell *CustomSongListTableCell::PopulateWithSongData(
       return this;
   }
 
-  if (songListObject->isDownloaded) {
-      auto versions = song.value().GetVersions();
-      if (!versions.empty()) {
-          auto &beatmap = versions.front();
-          std::string mapHash = beatmap.GetHash();
-          auto level = SongCore::API::Loading::GetLevelByHash(mapHash);
-          if (level == nullptr) {
-              songListObject->isDownloaded = false;
-              songListObject->songNotFound = true;
-          }
-      }
-  }
-
   if (songName)
       songName->set_text(song.value().GetName());
   if (levelAuthorName)

--- a/src/SongListCell.cpp
+++ b/src/SongListCell.cpp
@@ -21,6 +21,10 @@ CustomSongListTableCell *CustomSongListTableCell::PopulateWithSongData(
     statusLabel->set_text("Downloading...");
     this->entry = songListObject;
     return this;
+  } else if (songListObject->failed) {
+    statusLabel->set_text("Download Failed");
+    this->entry = songListObject;
+    return this;
   } else {
     statusLabel->set_text("Click to download");
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -198,8 +198,7 @@ extern "C" __attribute__((visibility("default"))) void late_load() {
   // QuestUI::Register::RegisterModSettingsViewController(modInfo, DidActivate);
   // QuestUI::Register::RegisterMainMenuModSettingsViewController(modInfo,
   // DidActivate);
-  BSML::Register::RegisterSettingsMenu("Twitch Song Request", DidActivate,
-                                       false);
+  BSML::Register::RegisterSettingsMenu("Twitch-ReQuest", DidActivate, false);
 
   INFO("Installing hooks...");
   INSTALL_HOOK(Logger, SceneManager_Internal_ActiveSceneChanged);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,7 @@
 #include "beatsaber-hook/shared/utils/hooking.hpp"
 #include "beatsaber-hook/shared/utils/il2cpp-utils.hpp"
 #include "beatsaverplusplus/shared/BeatSaver.hpp"
+#include "songcore/shared/SongCore.hpp"
 #include "bsml/shared/BSML.hpp"
 #include "bsml/shared/BSML/MainThreadScheduler.hpp"
 #include "custom-types/shared/register.hpp"
@@ -191,6 +192,7 @@ extern "C" __attribute__((visibility("default"))) void late_load() {
   custom_types::Register::AutoRegister();
 
   songDetails = SongDetailsCache::SongDetails::Init();
+  BeatSaver::API::Init(SongCore::API::Loading::GetPreferredCustomLevelPath());
 
   // Register settings menu
   // QuestUI::Register::RegisterModSettingsViewController(modInfo, DidActivate);


### PR DESCRIPTION
this is a bugfix for song downloading mentioned in #16 which also adds song covers and some ui overhaul. this was tested on beatsaber version 1.37.0 on my meta quest 3s modded with https://mbf.bsquest.xyz/. for testing this new version of the mod i also provide my locally built .qmod file down below. 

[TwitchSongReQuest.zip](https://github.com/user-attachments/files/24009608/TwitchSongReQuest.zip)

also here is the full bugfix and feature list of this pr:

- BUG: downloading songs now works 100% of the time (never had it fail while testing)
- BUG: fixing half cut off header "Song Requests". now fully visible
- BUG: not really a bug but for me the mod settings in main menu item was overflowing so i shortened it to "Twitch-ReQuest" so it is single line and not 2 lines and breaking mod settings ui
- FEATURE: show download progress as "Downloading... 42%" in status
- FEATURE: filling list from top so you don't have to scroll down on new requests
- FEATURE: showing song cover in request list
- FEATURE: added new state when download fails and song got deleted and needs to be redownloaded
- FEATURE: each state has now a dedicated color assigned to it

i kinda vibe coded half of the code but it works. maybe take a deeper look if you don't trust the code written by gemini 3 pro 😅